### PR TITLE
Add middle-mouse scrub to the piano roll

### DIFF
--- a/Source/UI/PianoRollComponent.cpp
+++ b/Source/UI/PianoRollComponent.cpp
@@ -1188,6 +1188,20 @@ void PianoRollComponent::mouseDown(const juce::MouseEvent &e)
   float adjustedX = e.x - pianoKeysWidth + static_cast<float>(scrollX);
   float adjustedY = e.y - headerHeight + static_cast<float>(scrollY);
 
+  // Middle-mouse scrub: click-and-drag anywhere in the timeline/canvas
+  // (ruler or note area) to move the playback cursor, mirroring Reaper's
+  // own middle-button scrub. Takes priority over every other gesture so
+  // held modifier keys never redirect it into zoom/pan.
+  if (e.mods.isMiddleButtonDown() && e.x >= pianoKeysWidth)
+  {
+    middleButtonScrubActive = true;
+    double time = std::max(0.0, xToTime(adjustedX));
+    setCursorTime(time);
+    if (onSeek)
+      onSeek(time);
+    return;
+  }
+
   if (isCanvasPoint(e) && isModifierZoomDrag(e))
   {
     modifierZoomDragActive = true;
@@ -1265,6 +1279,16 @@ void PianoRollComponent::mouseDown(const juce::MouseEvent &e)
 
 void PianoRollComponent::mouseDrag(const juce::MouseEvent &e)
 {
+  if (middleButtonScrubActive)
+  {
+    float adjustedX = e.x - pianoKeysWidth + static_cast<float>(scrollX);
+    double time = std::max(0.0, xToTime(adjustedX));
+    setCursorTime(time);
+    if (onSeek)
+      onSeek(time);
+    return;
+  }
+
   if (modifierZoomDragActive)
   {
     applyModifierZoomDrag(e);
@@ -1310,6 +1334,12 @@ void PianoRollComponent::mouseDrag(const juce::MouseEvent &e)
 
 void PianoRollComponent::mouseUp(const juce::MouseEvent &e)
 {
+  if (middleButtonScrubActive)
+  {
+    middleButtonScrubActive = false;
+    return;
+  }
+
   if (pianoKeyAuditionMouseDown)
   {
     pianoKeyAuditionMouseDown = false;

--- a/Source/UI/PianoRollComponent.h
+++ b/Source/UI/PianoRollComponent.h
@@ -401,6 +401,7 @@ private:
   bool modifierPanDragActive = false;
   juce::Point<float> modifierPanLastPosition;
   bool pianoKeyAuditionMouseDown = false;
+  bool middleButtonScrubActive = false;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(PianoRollComponent)
 };


### PR DESCRIPTION
Middle-click-drag anywhere in the piano roll now scrubs the playback cursor, like Reaper's own middle-mouse scrub. Click-to-seek already existed but only in the thin ruler strip; this extends it to the whole canvas and makes it continuous during a drag.

Reuses the existing `onSeek` path, so it inherits the same host-dependent behavior seeking already had: real-time scrubbing during playback needs ARA's `requestSetPlaybackPosition` (any ARA2 host, not Reaper-specific). In a plain non-ARA VST3/AU host there's no generic way for a plugin to move the host transport during playback, so scrubbing there only moves the cursor while stopped — same limitation the ruler click already had.

Tested locally in Reaper via ARA.