### PR TITLE
Restore ARA audio-thread safety in the render path

### DIFF
--- a/Source/Plugin/ARADocumentController.cpp
+++ b/Source/Plugin/ARADocumentController.cpp
@@ -358,13 +358,11 @@ void PitchNetPlaybackRenderer::prepareToPlay(
     docCtrl->processPlaybackRegions(getPlaybackRegions(), sampleRate);
   }
 
-  // Create readers for all playback regions
-  for (auto *region : getPlaybackRegions()) {
-    auto *source = region->getAudioModification()->getAudioSource();
-    if (readers.find(source) == readers.end())
-      readers.emplace(source,
-                      std::make_unique<juce::ARAAudioSourceReader>(source));
-  }
+  // Readers and resampler slots for the regions assigned so far. Regions the
+  // host assigns later arrive via didAddPlaybackRegion(), also on the model
+  // thread, so processBlock() never has to allocate.
+  for (auto *region : getPlaybackRegions<juce::ARAPlaybackRegion>())
+    ensureRenderResourcesFor(region);
 }
 
 void PitchNetPlaybackRenderer::releaseResources() {
@@ -372,6 +370,41 @@ void PitchNetPlaybackRenderer::releaseResources() {
   rawResamplingStates.clear();
   processedResamplingStates.clear();
   tempBuffer.reset();
+}
+
+void PitchNetPlaybackRenderer::ensureRenderResourcesFor(
+    juce::ARAPlaybackRegion *region) {
+  // Model thread only (prepareToPlay and region assignment). Allocating the
+  // reader and both resampler slots here is what keeps processBlock()
+  // allocation-free.
+  if (region == nullptr)
+    return;
+
+  rawResamplingStates.try_emplace(region);
+  processedResamplingStates.try_emplace(region);
+
+  auto *modification = region->getAudioModification();
+  auto *source =
+      modification != nullptr ? modification->getAudioSource() : nullptr;
+  if (source != nullptr && readers.find(source) == readers.end())
+    readers.emplace(source,
+                    std::make_unique<juce::ARAAudioSourceReader>(source));
+}
+
+void PitchNetPlaybackRenderer::didAddPlaybackRegion(
+    ARA::PlugIn::PlaybackRegion *playbackRegion) noexcept {
+  ensureRenderResourcesFor(
+      static_cast<juce::ARAPlaybackRegion *>(playbackRegion));
+}
+
+void PitchNetPlaybackRenderer::willRemovePlaybackRegion(
+    ARA::PlugIn::PlaybackRegion *playbackRegion) noexcept {
+  // Drop resampler state keyed by this pointer so a later region that reuses
+  // the address cannot inherit it. Readers are keyed by audio source and are
+  // cleared in releaseResources().
+  auto *region = static_cast<juce::ARAPlaybackRegion *>(playbackRegion);
+  rawResamplingStates.erase(region);
+  processedResamplingStates.erase(region);
 }
 
 bool PitchNetPlaybackRenderer::renderProcessedRegions(
@@ -419,27 +452,30 @@ bool PitchNetPlaybackRenderer::renderProcessedRegions(
           auto *source = modification->getAudioSource();
           const double modificationRate =
               source != nullptr ? source->getSampleRate() : 0.0;
-          renderedRegion = mixProcessedRegionAudio(
-              buffer, *region, data->audio, data->sampleRate,
-              data->startSampleInModification, modificationRate, sampleRate,
-              timeInSamples, &processedResamplingStates[region]);
+          // Never operator[] here: it would insert and allocate on the
+          // audio thread.
+          if (auto processedState = processedResamplingStates.find(region);
+              processedState != processedResamplingStates.end())
+            renderedRegion = mixProcessedRegionAudio(
+                buffer, *region, data->audio, data->sampleRate,
+                data->startSampleInModification, modificationRate, sampleRate,
+                timeInSamples, &processedState->second);
         }
       }
     }
 
     if (!renderedRegion && intersectsBlock) {
       auto *source = region->getAudioModification()->getAudioSource();
-      if (source != nullptr) {
-        auto it = readers.find(source);
-        if (it == readers.end())
-          it = readers
-                   .emplace(source, std::make_unique<juce::ARAAudioSourceReader>(
-                                        source))
-                   .first;
+      auto it = source != nullptr ? readers.find(source) : readers.end();
+      auto rawState = rawResamplingStates.find(region);
+      // Both are created on the model thread by ensureRenderResourcesFor().
+      // A miss means this region is not ready to render yet: skip it rather
+      // than allocating here.
+      if (it != readers.end() && rawState != rawResamplingStates.end()) {
         tempBuffer->clear();
         if (readPlaybackRegionIntoBlock(region, *it->second, sampleRate,
                                         timeInSamples, *tempBuffer,
-                                        &rawResamplingStates[region])) {
+                                        &rawState->second)) {
           for (int ch = 0; ch < std::min(buffer.getNumChannels(),
                                          tempBuffer->getNumChannels());
                ++ch)
@@ -458,14 +494,23 @@ bool PitchNetPlaybackRenderer::renderProcessedRegions(
 bool PitchNetPlaybackRenderer::processBlock(
     juce::AudioBuffer<float> &buffer, juce::AudioProcessor::Realtime realtime,
     const juce::AudioPlayHead::PositionInfo &posInfo) noexcept {
+  // Get document controller for accessing MainComponent
+  auto *docCtrl = getDocController();
+  if (!docCtrl)
+    return true;
+
+  // Produce nothing while the host is mutating the model graph: any region
+  // this block would read may be freed before the block finishes.
+  const auto processingLock = docCtrl->getProcessingLock();
+  if (!processingLock.isLocked())
+    return true;
+
   auto timeInSamples = posInfo.getTimeInSamples().orFallback(0);
   bool isPlaying = posInfo.getIsPlaying();
   int numSamples = buffer.getNumSamples();
   const bool shouldSyncUi = (realtime == juce::AudioProcessor::Realtime::yes);
   const bool hasPlaybackRegions = !getPlaybackRegions().empty();
 
-  // Get document controller for accessing MainComponent
-  auto *docCtrl = getDocController();
   syncHostLoopState(docCtrl, posInfo, shouldSyncUi);
 
   auto notifyHostStopped = [&]() {
@@ -562,18 +607,29 @@ void PitchNetEditorRenderer::prepareToPlay(
   previewLoopPosition = 0;
 
   readers.clear();
+  mayCreateReadersWhileRendering = (alwaysNonRealtime == AlwaysNonRealtime::yes);
   if (alwaysNonRealtime == AlwaysNonRealtime::yes)
     return;
 
-  for (auto *region : getPlaybackRegions()) {
-    if (!region || !region->getAudioModification())
-      continue;
+  for (auto *region : getPlaybackRegions<juce::ARAPlaybackRegion>())
+    ensureReaderFor(region);
+}
 
-    auto *source = region->getAudioModification()->getAudioSource();
-    if (source && readers.find(source) == readers.end())
-      readers.emplace(source,
-                      std::make_unique<juce::ARAAudioSourceReader>(source));
-  }
+void PitchNetEditorRenderer::ensureReaderFor(juce::ARAPlaybackRegion *region) {
+  // Model thread only (prepareToPlay and region assignment).
+  if (region == nullptr || region->getAudioModification() == nullptr)
+    return;
+
+  auto *source = region->getAudioModification()->getAudioSource();
+  if (source != nullptr && readers.find(source) == readers.end())
+    readers.emplace(source,
+                    std::make_unique<juce::ARAAudioSourceReader>(source));
+}
+
+void PitchNetEditorRenderer::didAddPlaybackRegion(
+    ARA::PlugIn::PlaybackRegion *playbackRegion) noexcept {
+  if (!mayCreateReadersWhileRendering)
+    ensureReaderFor(static_cast<juce::ARAPlaybackRegion *>(playbackRegion));
 }
 
 void PitchNetEditorRenderer::releaseResources() {
@@ -599,10 +655,17 @@ bool PitchNetEditorRenderer::readPlaybackRangeIntoBuffer(
     return false;
 
   auto it = readers.find(source);
-  if (it == readers.end())
+  if (it == readers.end()) {
+    // Reached from processBlock() via renderPreviewBuffer(). On a realtime
+    // thread a miss means this region has no reader yet: give up rather than
+    // allocate. Offline rendering is not realtime and has no pre-made readers,
+    // so it is allowed to create one here.
+    if (!mayCreateReadersWhileRendering)
+      return false;
     it = readers.emplace(source, std::make_unique<juce::ARAAudioSourceReader>(
                                      source))
              .first;
+  }
 
   const auto sourceSampleRate = source->getSampleRate();
   const int sourceChannels = source->getChannelCount();
@@ -889,6 +952,12 @@ bool PitchNetEditorRenderer::processBlock(
 
   auto *docCtrl = getDocController();
   if (!docCtrl)
+    return true;
+
+  // See PitchNetPlaybackRenderer::processBlock(): the editor renderer reads
+  // the same regions and needs the same exclusion during host graph edits.
+  const auto processingLock = docCtrl->getProcessingLock();
+  if (!processingLock.isLocked())
     return true;
 
   auto &previewState = docCtrl->getPreviewState();
@@ -2034,10 +2103,20 @@ void PitchNetDocumentController::willDestroyRegionSequence(
   currentPlaybackRegion = nullptr;
 }
 
+juce::ScopedTryReadLock PitchNetDocumentController::getProcessingLock() {
+  return juce::ScopedTryReadLock{processBlockLock};
+}
+
 void PitchNetDocumentController::willBeginEditing(juce::ARADocument *document) {
   hostEditing = true;
   splitSnapshots.clear();
   deferredRegionUpdates.clear();
+
+  // Snapshot before taking the write lock. This pass only reads the graph and
+  // the host has not begun mutating it yet, so the audio thread may keep
+  // rendering while we copy. Holding the lock across a per-region Project copy
+  // of the whole document would stall playback audibly on a large session.
+  [&] {
   auto *processor = getRegionCanvasProcessor();
   if (!processor || !document)
     return;
@@ -2111,6 +2190,13 @@ void PitchNetDocumentController::willBeginEditing(juce::ARADocument *document) {
           }
         }
       }
+  }();
+
+  // Exclude the audio thread for the duration of the host's graph edit. Paired
+  // with exitWrite() in didEndEditing(); enterWrite() must run on every path,
+  // which is why the snapshot above is scoped in a lambda instead of returning
+  // early out of this function.
+  processBlockLock.enterWrite();
 }
 
 void PitchNetDocumentController::didEndEditing(juce::ARADocument *document) {
@@ -2294,6 +2380,10 @@ void PitchNetDocumentController::didEndEditing(juce::ARADocument *document) {
   }
   hostEditing = false;
   splitSnapshots.clear();
+  // The graph is stable again. Let the audio thread back in before the tail
+  // below, which reads source audio and dispatches analysis and must not run
+  // with the render path locked out.
+  processBlockLock.exitWrite();
   auto updates = std::move(deferredRegionUpdates);
   deferredRegionUpdates.clear();
   for (auto *region : updates)

--- a/Source/Plugin/ARADocumentController.h
+++ b/Source/Plugin/ARADocumentController.h
@@ -112,6 +112,14 @@ private:
                          const juce::AudioPlayHead::PositionInfo &posInfo,
                          bool shouldSyncUi);
 
+  // Region assignment happens on the model thread, so readers and resampler
+  // slots are allocated there rather than lazily inside processBlock().
+  void ensureRenderResourcesFor(juce::ARAPlaybackRegion *region);
+  void didAddPlaybackRegion(
+      ARA::PlugIn::PlaybackRegion *playbackRegion) noexcept override;
+  void willRemovePlaybackRegion(
+      ARA::PlugIn::PlaybackRegion *playbackRegion) noexcept override;
+
   std::map<juce::ARAAudioSource *, std::unique_ptr<juce::ARAAudioSourceReader>>
       readers;
   // Persistent resampler state per region, split by source so a failed processed
@@ -153,8 +161,15 @@ private:
                           juce::int64 timeInSamples, int numSamples);
   PitchNetDocumentController *getDocController() const;
 
+  void ensureReaderFor(juce::ARAPlaybackRegion *region);
+  void didAddPlaybackRegion(
+      ARA::PlugIn::PlaybackRegion *playbackRegion) noexcept override;
+
   std::map<juce::ARAAudioSource *, std::unique_ptr<juce::ARAAudioSourceReader>>
       readers;
+  // Offline rendering intentionally starts with no readers and does not run on
+  // a realtime thread, so it may still create one on demand mid-render.
+  bool mayCreateReadersWhileRendering = false;
   std::shared_ptr<juce::AudioBuffer<float>> previewBuffer;
   std::shared_ptr<juce::AudioBuffer<float>> previousPreviewBuffer;
   juce::Range<juce::int64> previewLoopRange;
@@ -279,6 +294,13 @@ public:
   AraPreviewState &getPreviewState() { return previewState; }
   const AraPreviewState &getPreviewState() const { return previewState; }
 
+  // Excludes the audio thread while the host mutates the ARA model graph.
+  // Renderers take this for read in processBlock() and produce nothing when it
+  // is unavailable, so a playback region cannot be destroyed out from under a
+  // render that is mid-read. Mirrors the ProcessingLockInterface pattern in
+  // JUCE's ARAPluginDemo.
+  juce::ScopedTryReadLock getProcessingLock();
+
 protected:
   juce::ARAPlaybackRenderer *doCreatePlaybackRenderer() noexcept override;
   juce::ARAEditorRenderer *doCreateEditorRenderer() override;
@@ -333,6 +355,9 @@ private:
     std::atomic<bool> cancel{false};
   };
 
+  // Write-held across the host's editing cycle (willBeginEditing ->
+  // didEndEditing); try-read-held by both renderers' processBlock().
+  juce::ReadWriteLock processBlockLock;
   IMainView *mainComponent = nullptr;
   juce::ARAAudioSource *currentAudioSource = nullptr;
   juce::ARADocument *currentDocument = nullptr;


### PR DESCRIPTION
## Summary

This addresses two realtime-audio defects in the ARA render path which can cause crashing. 

**1. Editing a clip during playback can crash the plugin.** The audio thread walks the list of playback regions and reads from each one while the DAW is free to delete those same objects. Split, delete, or drag a clip while the transport is rolling and you can land in freed memory. It's timing-dependent, so it surfaces as "it crashed once" or "the audio went weird for a second" — reports that can't be reproduced on demand and can't be debugged. If you have open issues like that, this is a likely cause.

**2. The audio thread allocates memory on every block under some conditions.** That's a textbook source of clicks, pops, and dropouts, and it gets blamed on the plugin. This removes it.

**What it costs:** ~175 lines across 2 files. The only behaviour change is a brief gap in audio at the instant you split or delete a clip *while playing*. In my testing that wasn't objectionable. You're trading an unpredictable crash for a predictable few milliseconds of silence.

**Why it's low risk:** it restores a synchronisation pattern that was already in this codebase until recently, and which is the pattern JUCE's own ARA example uses. Nothing new is being invented.

## Technical Details

### The synchronisation

`PitchNetDocumentController` used to hold a `ReadWriteLock` — write-held across `willBeginEditing`/`didEndEditing`, try-read-held by both renderers' `processBlock` — which is the `ProcessingLockInterface` pattern from `ARAPluginDemo.h:307`, the JUCE example this code follows. It's since been replaced by a `bool hostEditing`.

The bool records *that* a host edit is in progress but doesn't make anyone wait, so it doesn't close the window the lock was there for. `renderProcessedRegions()` iterates `getPlaybackRegions()` and dereferences each region, and keys resampler state by raw `ARAPlaybackRegion*`, while `willDestroyPlaybackRegion()` runs on the model thread and the host frees those objects immediately after. Editing the arrangement during playback can therefore free a region mid-read. It's timing-dependent, so it shows up as an occasional crash or a burst of garbage audio rather than anything reproducible.

### The allocations

`processBlock` also constructs `ARAAudioSourceReader` objects and inserts into the resampler maps via `operator[]` — both allocate. This moves reader and resampler-slot creation to the model thread (`prepareToPlay` plus new `didAddPlaybackRegion` overrides), switches the render path to `find()` with a skip on miss, and erases stale entries in `willRemovePlaybackRegion` so a new region that reuses a freed address can't inherit another region's resampler state. Offline rendering keeps creating readers on demand, since it starts with none by design and isn't realtime.

### Development Cost

The lock probably caused audible glitching — `willBeginEditing` copies a `Project` per region across the whole document, and holding a write lock across that would stall playback badly.

This version runs that snapshot *before* `enterWrite()`. It's a read-only pass and the host hasn't begun mutating the graph yet, so the audio thread can keep rendering through it. `exitWrite()` lands in `didEndEditing` after the reconstruction but before the analysis/UI tail, which reads source audio and shouldn't hold the render path out.

What remains is a brief gap at the moment of a structural edit — splitting, deleting, moving a clip — and only while the transport is rolling. In my testing that gap wasn't very noticeable. It's also what the JUCE example accepts by design: the renderer produces nothing for blocks where it can't take the lock.

### Verifying

With the transport rolling, split/delete/move clips repeatedly. Before: occasional crashes or corrupted audio, not reliably reproducible. After: a short gap at the edit, then normal playback.

The lock boundaries can be adjusted if the gap is worse on larger sessions; narrowing what's inside `didEndEditing` is the method to do so.


